### PR TITLE
Fixing transparent window titles

### DIFF
--- a/gtk-3.0/gtk.css
+++ b/gtk-3.0/gtk.css
@@ -1585,7 +1585,7 @@ headerbar {
   padding: 4px 8px;
   min-height: 32px;
   color: #FFFFFF;
-  background-color: rgba(31, 31, 31, 0.95);
+  background-color: rgba(31, 31, 31, 1);
   border-bottom: 1px solid #333333; }
   headerbar:backdrop {
     background-color: #000000;


### PR DESCRIPTION
As suggested by [This issue#4 on the white theme](https://github.com/B00merang-Project/Windows-10-Acrylic/issues/4#issuecomment-1326687287).